### PR TITLE
Expose the OpenTelemetry collector through Traefik

### DIFF
--- a/socialapp/docker-compose.yml
+++ b/socialapp/docker-compose.yml
@@ -942,6 +942,16 @@ services:
     depends_on:
       - tempo
       - prometheus
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.otel.rule=Host(`otel.internal.${EXPOSED_HOST}`)"
+      - "traefik.http.routers.otel.entrypoints=websecure"
+      - "traefik.http.routers.otel.tls=true"
+      - "traefik.http.routers.otel.tls.certresolver=letsencrypt-dns"
+      - "traefik.http.routers.otel-http.rule=Host(`otel.internal.${EXPOSED_HOST}`)"
+      - "traefik.http.routers.otel-http.entrypoints=web"
+      - "traefik.http.routers.otel-http.middlewares=https-redirect"
+      - "traefik.http.services.otel.loadbalancer.server.port=4318"
     logging:
       driver: loki
       options:


### PR DESCRIPTION
## Summary
- Added Traefik labels to the `otel-collector` service in `socialapp/docker-compose.yml`
- Exposed the collector at `otel.internal.${EXPOSED_HOST}` with HTTPS and HTTP-to-HTTPS redirect
- Routed traffic to the collector's OTLP HTTP port `4318`

## Testing
- Validated the compose configuration with `EXPOSED_HOST` set and environment file resolution disabled
- Confirmed the updated service labels render correctly through Compose interpolation